### PR TITLE
Improved generalization of Positions to n-D

### DIFF
--- a/src/Positions/Positions.jl
+++ b/src/Positions/Positions.jl
@@ -176,8 +176,10 @@ function getindex(grid::RegularGridPositions, i::Integer)
     idx = [i]
   elseif length(grid.shape) == 2
     idx = collect(Tuple((CartesianIndices(tuple(grid.shape[1],grid.shape[2])))[i]))
-  else
+  elseif length(grid.shape) == 3
     idx = collect(Tuple((CartesianIndices(tuple(grid.shape[1],grid.shape[2],grid.shape[3])))[i]))
+  else
+    idx = collect(Tuple((CartesianIndices(tuple(grid.shape...)))[i]))
   end
 
   for d=1:length(idx)
@@ -303,10 +305,11 @@ end
 
 function indexPermutation(grid::MeanderingGridPositions, i::Integer)
   dims = tuple(shape(grid)...)
+  ndims = length(dims)
   idx = collect(Tuple(CartesianIndices(dims)[i]))
-    for d=2:3
-      if isodd(sum(idx[d:3])-length(idx[d:3]))
-      idx[d-1] = shape(grid)[d-1] + 1 - idx[d-1]
+    for d=1:ndims-1
+      if isodd(sum(idx[d+1:end])-(ndims-d))
+      idx[d] = -idx[d] + shape(grid)[d] + 1
     end
   end
   linidx = (LinearIndices(dims))[idx...]


### PR DESCRIPTION
MeanderingGridPositions was not correctly defined for a 2D grid, since the implementation was assuming the grid to be 3D. I updated the code to generalize to N-D. Also it was not possible to create a RegularGrid with more than three dimensions, which is probably not relevant anyways but at least now you are able to.