### PR TITLE
Fix squared positions when creating from Unitful dict

### DIFF
--- a/src/Positions/Positions.jl
+++ b/src/Positions/Positions.jl
@@ -87,14 +87,24 @@ function RegularGridPositions(file::HDF5.File)
   shape = read(file, "/positionsShape")
   fov = read(file, "/positionsFov")*Unitful.m
   center = read(file, "/positionsCenter")*Unitful.m
-  return RegularGridPositions(shape,fov,center)
+
+  return RegularGridPositions(shape, fov, center)
 end
 
 function RegularGridPositions(params::Dict)
   shape = params["positionsShape"]
-  fov = params["positionsFov"]*Unitful.m
-  center = params["positionsCenter"]*Unitful.m
-  return RegularGridPositions(shape,fov,center)
+
+  fov = params["positionsFov"]
+  if !(eltype(fov) <: Quantity)
+    fov = fov.*Unitful.m
+  end
+
+  center = params["positionsCenter"]
+  if !(eltype(center) <: Quantity)
+    center = center.*Unitful.m
+  end
+
+  return RegularGridPositions(shape, fov, center)
 end
 
 # Find a joint grid
@@ -251,8 +261,17 @@ end
 
 function ChebyshevGridPositions(params::Dict)
   shape = params["positionsShape"]
-  fov = params["positionsFov"]*Unitful.m
-  center = params["positionsCenter"]*Unitful.m
+
+  fov = params["positionsFov"]
+  if !(eltype(fov) <: Quantity)
+    fov = fov.*Unitful.m
+  end
+
+  center = params["positionsCenter"]
+  if !(eltype(center) <: Quantity)
+    center = center.*Unitful.m
+  end
+
   return ChebyshevGridPositions(shape,fov,center)
 end
 
@@ -355,7 +374,12 @@ end
 
 function BreakpointGridPositions(params::Dict)
   typ = params["positionsType"]
-  breakpointPosition = params["positionsBreakpoint"] * Unitful.m
+
+  breakpointPosition = params["positionsBreakpoint"]
+  if !(eltype(breakpointPosition) <: Quantity)
+    breakpointPosition = breakpointPosition.*Unitful.m
+  end
+
   breakpointIndices = params["indicesBreakpoint"]
 
   if typ == "MeanderingGridPositions"

--- a/test/Positions.jl
+++ b/test/Positions.jl
@@ -294,4 +294,18 @@ pospath = joinpath(tmpdir,"positions","Positions.h5")
   for (i,p) in enumerate(caG)
     @test p == caG[i]
   end
+
+  @testset "Squared positions regression test" begin
+    # When supplying a dict already equipped with Unitful units, the positions were squared
+    params = Dict{String, Any}()
+    params["positionsShape"] = [3, 3, 3]
+    params["positionsFov"] = [3.0u"mm", 3.0u"mm", 3.0u"mm"]
+    params["positionsCenter"] = [0.0u"mm", 0.0u"mm", 0.0u"mm"]
+
+    positions = RegularGridPositions(params)
+    @test eltype(positions[1]) <: Unitful.Length
+
+    positions = ChebyshevGridPositions(params)
+    @test eltype(positions[1]) <: Unitful.Length
+  end
 end


### PR DESCRIPTION
Running the code

```
params = Dict{String, Any}()
params["positionsShape"] = [3, 3, 3]
params["positionsFov"] = [3.0u"mm", 3.0u"mm", 3.0u"mm"]
params["positionsCenter"] = [0.0u"mm", 0.0u"mm", 0.0u"mm"]
positions = RegularGridPositions(params)
```

resulted in 

`RegularGridPositions{Quantity{Float64, 𝐋 ^2, Unitful.FreeUnits{(mm, m), 𝐋 ^2, nothing}}}([3, 3, 3], Quantity{Float64, 𝐋^2, Unitful.FreeUnits{(mm, m), 𝐋^2, nothing}}[3.0 mm m, 3.0 mm m, 3.0 mm m], Quantity{Float64, 𝐋^2, Unitful.FreeUnits{(mm, m), 𝐋^2, nothing}}  [0.0 mm m, 0.0 mm m, 0.0 mm m], [1, 1, 1])`


The squared dimension of length stems from assuming the dict values to be regular numbers. When used with Unitful, this results in the seen misinterpretation. I added a behaviour change for Unitful vectors and a matching regression test.