### PR TITLE
Moved Bruker UUID Generation and UniformRandomPositions to StableRNG

### DIFF
--- a/src/Brukerfile.jl
+++ b/src/Brukerfile.jl
@@ -186,7 +186,7 @@ studyNameOld(b::BrukerFile) = string(latin1toutf8(b["VisuSubjectId"])*latin1tout
                                   b["VisuStudyNumber"])
 studyNumber(b::BrukerFile) = parse(Int64,b["VisuStudyNumber"])
 function studyUuid(b::BrukerFile)
-  rng = MersenneTwister(hash(b["VisuStudyUid"])) # use VisuStudyUid as seed to generate uuid4
+  rng = StableRNG(hash(b["VisuStudyUid"])) # use VisuStudyUid as seed to generate uuid4
   return uuid4(rng)
 end
 studyDescription(b::BrukerFile) = "n.a."
@@ -207,7 +207,7 @@ function experimentNumber(b::BrukerFile)
 end
 
 function experimentUuid(b::BrukerFile)
-  rng = MersenneTwister(hash(b["VisuUid"])) # use VisuUid as seed to generate uuid4
+  rng = StableRNG(hash(b["VisuUid"])) # use VisuUid as seed to generate uuid4
   return uuid4(rng)
 end
 experimentDescription(b::BrukerFile) = latin1toutf8(b["ACQ_scan_name"])

--- a/src/Positions/Positions.jl
+++ b/src/Positions/Positions.jl
@@ -489,8 +489,8 @@ function getindex(rpos::UniformRandomPositions{AxisAlignedBox}, i::Integer)
     throw(BoundsError(rpos,i))
   else
     # make sure Positions are randomly generated from given seed
-    mersenneTwister = MersenneTwister(seed(rpos))
-    rP = rand(mersenneTwister, 3, i)[:,i]
+    rng = StableRNG(seed(rpos))
+    rP = rand(rng, 3, i)[:,i]
     return (rP.-0.5).*fieldOfView(rpos)+fieldOfViewCenter(rpos)
   end
 end
@@ -500,9 +500,9 @@ function getindex(rpos::UniformRandomPositions{Ball}, i::Integer)
     throw(BoundsError(rpos,i))
   else
     # make sure Positions are randomly generated from given seed
-    mersenneTwister = MersenneTwister(seed(rpos))
-    D = rand(mersenneTwister, i)[i]
-    P = randn(mersenneTwister, 3, i)[:,i]
+    rng = StableRNG(seed(rpos))
+    D = rand(rng, i)[i]
+    P = randn(rng, 3, i)[:,i]
     return radius(rpos)*D^(1/3)*normalize(P)+fieldOfViewCenter(rpos)
   end
 end

--- a/test/Positions.jl
+++ b/test/Positions.jl
@@ -228,9 +228,9 @@ pospath = joinpath(tmpdir,"positions","Positions.h5")
   @test domain.fov == fov
   @test domain.center == ctr
   rP1 = UniformRandomPositions(N,seed,domain)
-  @test rP1[1] == [0.09954904813158394,-0.13791259323857274,-1.446939519855107]Unitful.mm
-  @test rP1[2] == [-0.9812009131891462,1.3767776289892044,1.4206979394110573]Unitful.mm
-  @test rP1[3] == [-0.5883911667396526,-0.9692742011014337,1.3707474722677764]Unitful.mm
+  @test rP1[1] == [0.24154458805558643, -0.9262755616254505, 1.413400404619357]Unitful.mm
+  @test rP1[2] == [0.7303493695629726, -0.9870943521080697, 0.6143278667437428]Unitful.mm
+  @test rP1[3] == [-0.17686922698492702, 0.911915746834733, 0.817151846349423]Unitful.mm
   @test_throws BoundsError rP1[0]
   @test_throws BoundsError rP1[4]
   h5open(pospath, "w") do file
@@ -249,7 +249,7 @@ pospath = joinpath(tmpdir,"positions","Positions.h5")
   @test domain.radius == radius
   @test domain.center == ctr
   rP3 = UniformRandomPositions(N,seed,domain)
-  @test rP3[1] == [-6.715713750009747,0.4103832286623821,-4.525933276650638]Unitful.mm
+  @test rP3[1] == [1.9129764588101597, 5.876973430472611, 5.6027641441895994]Unitful.mm
   @test_throws BoundsError rP3[0]
   @test_throws BoundsError rP3[4]
   h5open(pospath, "w") do file


### PR DESCRIPTION
Julia 1.11 changed the RNG behaviour, causing the fixed seeds to give different random values for 1.10 and 1.11. Since this would break stuff anyways, we can now switch to StableRNG

Fixes #32 #108 