### PR TITLE
Fix `getMeasurements` and `getMeasurementsFD` for frequency-selected data

### DIFF
--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -285,6 +285,7 @@ function getMeasurements(f::MPIFile, neglectBGFrames=true;
 
     # Pad transfer function in frequency-selected data to prevent errors after conversion from frequency to time domain.
     if (size(tf, 1) != size(dataF)) && measIsFrequencySelection(f)
+      @warn "This MDF is saved in the frequency domain and has been frequency-selected. Converting to time domain is inherently missing frequency components."
       tfPadded = fill(eltype(tf)(Inf), (rxNumFrequencies(f), size(tf, 2)))
       tfPadded[measFrequencySelection(f), :] = tf
       tf = tfPadded


### PR DESCRIPTION
The MDF defines the tf to be CxK and K is not matching the padded data after loading. This mismatch causes the following division of the data by the tf to fail.

Related: #98